### PR TITLE
Check for existence of CommonLibSSEPath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ endmacro()
 
 set_from_environment(Skyrim64Path)
 set_from_environment(VCPKG_ROOT)
+set_from_environment(CommonLibSSEPath)
 
 if (DEFINED VCPKG_ROOT)
 	set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")
@@ -24,6 +25,7 @@ else ()
 		"Variable VCPKG_ROOT is not set. Continuing without vcpkg."
 	)
 endif ()
+
 
 set(Boost_USE_STATIC_RUNTIME OFF CACHE BOOL "")
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL" CACHE STRING "")
@@ -82,8 +84,15 @@ set(Boost_USE_STATIC_LIBS ON)
 
 
 # ---- Dependencies ----
+if (DEFINED CommonLibSSEPath AND NOT ${CommonLibSSEPath} STREQUAL "" AND IS_DIRECTORY ${CommonLibSSEPath})
+	add_subdirectory(${CommonLibSSEPath} CommonLibSSE)
+else ()
+	message(
+		FATAL_ERROR
+		"Variable CommonLibSSEPath is not set."
+	)
+endif ()
 
-add_subdirectory("$ENV{CommonLibSSEPath}" CommonLibSSE)
 
 find_package(Boost MODULE REQUIRED)
 find_package(spdlog REQUIRED CONFIG)


### PR DESCRIPTION
Fixes bug where an unset CommonLibSSEPath would result in the build directory creating an infinite recursion of CommonLibSSE subdirectories. This would result in a `Maximum recursion depth of 1000 exceeded` cmake error and potentially make Windows unable to delete the build directory due to the path length.