### PR TITLE
Add some build instructions for a fresh install

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,31 @@
 SKSE64 plugin that expands Papyrus script functionality, with 276 functions, 29 events, 4 script objects for Skyrim Special Edition. 
 
 Documentation for each function is listed within the Papyrus source files (.psc extension).
+
+## Requirements
+* [CMake](https://cmake.org/)
+	* Add this to your `PATH`
+* [PowerShell](https://github.com/PowerShell/PowerShell/releases/latest)
+* [Vcpkg](https://github.com/microsoft/vcpkg)
+	* Add the environment variable `VCPKG_ROOT` with the value as the path to the folder containing vcpkg
+* [Visual Studio Community 2019](https://visualstudio.microsoft.com/)
+	* Desktop development with C++
+* [CommonLibSSE](https://github.com/powerof3/CommonLibSSE/tree/dev)
+	* You need to build from the powerof3/dev branch
+	* Add this as as an environment variable `CommonLibSSEPath`
+
+## Register Visual Studio as a Generator
+* Open `x64 Native Tools Command Prompt`
+* Run `cmake`
+* Close the cmd window
+
+## Building
+```
+git clone https://github.com/powerof3/PapyrusExtenderSSE.git
+cd PapyrusExtenderSSE
+cmake -B build -S .
+```
+Open build/po3_PapyrusExtender.sln in Visual Studio to build dll.
+
+## License
+[MIT](LICENSE)

--- a/src/C++/main.cpp
+++ b/src/C++/main.cpp
@@ -6,7 +6,7 @@ static std::vector<std::string> DetectOldVersion()
 {
 	std::vector<std::string> vec;
 
-	const auto papyrusExtender64Handle = GetModuleHandle("po3_papyrusextender64");
+	const auto papyrusExtender64Handle = GetModuleHandleA("po3_papyrusextender64");
 
 	std::string message;
 	std::string info;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "dependencies": [
     "boost-stl-interfaces",
+    "boost-algorithm",
     "frozen",
     "spdlog",
     "xbyak"


### PR DESCRIPTION
Tested on a fresh install of VS2019.

I had to change GetModuleHandle to GetModuleHandleA as it was being set to GetModuleHandleW because `_UNICODE` was being set by cmake. I don't think it'll impact anything, but wanted to flag that change.