### PR TITLE
IsRefNodeInWater incorrectly checks if a_nodeName is empty or not.

### DIFF
--- a/src/Papyrus/Functions/ObjectReference.cpp
+++ b/src/Papyrus/Functions/ObjectReference.cpp
@@ -1024,7 +1024,7 @@ namespace Papyrus::ObjectReference
 
 		RE::NiAVObject* node = nullptr;
 
-		if (!a_nodeName.empty()) {
+		if (a_nodeName.empty()) {
 			node = root;
 		} else {
 			node = root->GetObjectByName(a_nodeName);


### PR DESCRIPTION
The if statement is inverted.